### PR TITLE
Fix example xacro + Change to OS1-64 datasheet parameters

### DIFF
--- a/ouster_description/urdf/OS1-64.urdf.xacro
+++ b/ouster_description/urdf/OS1-64.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="OS1-64">
   <xacro:property name="M_PI" value="3.1415926535897931" />
-  <xacro:macro name="OS1-64" params="*origin parent:=base_link name:=os1_sensor topic_points:=/os1_cloud_node/points topic_imu:=/os1_cloud_node/imu hz:=10 lasers:=64 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os1_lidar imu_link:=os1_imu vfov_min:=-.26 vfov_max:=.26">
+  <xacro:macro name="OS1-64" params="*origin parent:=base_link name:=os1_sensor topic_points:=/os1_cloud_node/points topic_imu:=/os1_cloud_node/imu hz:=10 lasers:=64 samples:=512 min_range:=0.25 max_range:=75.0 noise:=0.009 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os1_lidar imu_link:=os1_imu vfov_min:=-.39 vfov_max:=.39">
 
     <joint name="${name}_mount_joint" type="fixed">
       <xacro:insert_block name="origin" /> 
@@ -11,15 +11,15 @@
 
     <link name="${name}">
       <inertial>
-         <mass value="0.33"/>
+         <mass value="0.455"/>
          <origin xyz="0 0 0.0365" rpy="0 0 0" />
-         <inertia ixx="0.000241148" ixy="0" ixz="0"
-          iyy="0.000241148" iyz="0" izz="0.000264"/>
+         <inertia ixx="0.000435" ixy="0" ixz="0"
+          iyy="0.000435" iyz="0" izz="0.000461"/>
       </inertial>
       <collision name="base_collision">
          <origin xyz="0 0 0.0365" rpy="0 0 0" />
          <geometry>
- 	        <cylinder radius="0.04" length="0.073"/>
+ 	        <cylinder radius="0.045" length="0.0735"/>
          </geometry>
       </collision>
       <visual name="base_visual">

--- a/ouster_description/urdf/example.urdf.xacro
+++ b/ouster_description/urdf/example.urdf.xacro
@@ -31,7 +31,7 @@
   </link>
 
   <xacro:include filename="$(find ouster_description)/urdf/OS1-64.urdf.xacro"/>
-  <OS1-64 parent="base_link" name="os1_sensor" hz="10" samples="220">
+  <OS1-64 parent="base_link" name="os1_sensor">
     <origin xyz="0 0 1.2" rpy="0 0 0" />
   </OS1-64>
 


### PR DESCRIPTION
Parameters from [ouster OS1-64 datasheet web](http://data.ouster.io/downloads/OS1-lidar-sensor-datasheet.pdf)
Inertia calculation using a cylinder model

Example xacro now uses default configuration (10 Hz + 512 resolution). Change in OS1-64.urdf.xacro for different frequencies and resolutions.